### PR TITLE
fix (#5): the tests package should not be renamed

### DIFF
--- a/packages/apis/admin_test.go
+++ b/packages/apis/admin_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminAuthWithPassword(t *testing.T) {

--- a/packages/apis/backup_test.go
+++ b/packages/apis/backup_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 	"gocloud.dev/blob"
 )
 

--- a/packages/apis/base_test.go
+++ b/packages/apis/base_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/apis"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 	"github.com/spf13/cast"
 )
 

--- a/packages/apis/collection_test.go
+++ b/packages/apis/collection_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestCollectionsList(t *testing.T) {

--- a/packages/apis/file_test.go
+++ b/packages/apis/file_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/daos"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestFileToken(t *testing.T) {

--- a/packages/apis/health_test.go
+++ b/packages/apis/health_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestHealthAPI(t *testing.T) {

--- a/packages/apis/logs_test.go
+++ b/packages/apis/logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v5"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRequestsList(t *testing.T) {

--- a/packages/apis/middlewares_test.go
+++ b/packages/apis/middlewares_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/apis"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRequireGuestOnly(t *testing.T) {

--- a/packages/apis/realtime_test.go
+++ b/packages/apis/realtime_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/hook"
 	"github.com/pocketbase/pocketbase/packages/tools/subscriptions"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRealtimeConnect(t *testing.T) {

--- a/packages/apis/record_auth_test.go
+++ b/packages/apis/record_auth_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/daos"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/subscriptions"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordAuthMethodsList(t *testing.T) {

--- a/packages/apis/record_crud_test.go
+++ b/packages/apis/record_crud_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordCrudList(t *testing.T) {

--- a/packages/apis/record_helpers_test.go
+++ b/packages/apis/record_helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/apis"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRequestInfo(t *testing.T) {

--- a/packages/apis/settings_test.go
+++ b/packages/apis/settings_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase/packages/core"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestSettingsList(t *testing.T) {

--- a/packages/cmd/admin_test.go
+++ b/packages/cmd/admin_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/cmd"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminCreateCommand(t *testing.T) {

--- a/packages/core/base_backup_test.go
+++ b/packages/core/base_backup_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/core"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/archive"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestCreateBackup(t *testing.T) {

--- a/packages/core/base_settings_test.go
+++ b/packages/core/base_settings_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestBaseAppRefreshSettings(t *testing.T) {

--- a/packages/daos/admin_test.go
+++ b/packages/daos/admin_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminQuery(t *testing.T) {

--- a/packages/daos/base_test.go
+++ b/packages/daos/base_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNew(t *testing.T) {

--- a/packages/daos/collection_test.go
+++ b/packages/daos/collection_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestCollectionQuery(t *testing.T) {

--- a/packages/daos/external_auth_test.go
+++ b/packages/daos/external_auth_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestExternalAuthQuery(t *testing.T) {

--- a/packages/daos/param_test.go
+++ b/packages/daos/param_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestParamQuery(t *testing.T) {

--- a/packages/daos/record_expand_test.go
+++ b/packages/daos/record_expand_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestExpandRecords(t *testing.T) {

--- a/packages/daos/record_table_sync_test.go
+++ b/packages/daos/record_table_sync_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestSyncRecordTableSchema(t *testing.T) {

--- a/packages/daos/record_test.go
+++ b/packages/daos/record_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordQueryWithDifferentCollectionValues(t *testing.T) {

--- a/packages/daos/request_test.go
+++ b/packages/daos/request_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRequestQuery(t *testing.T) {

--- a/packages/daos/settings_test.go
+++ b/packages/daos/settings_test.go
@@ -3,8 +3,8 @@ package daos_test
 import (
 	"testing"
 
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestSaveAndFindSettings(t *testing.T) {

--- a/packages/daos/table_test.go
+++ b/packages/daos/table_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestHasTable(t *testing.T) {

--- a/packages/daos/view_test.go
+++ b/packages/daos/view_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func ensureNoTempViews(app core.App, t *testing.T) {

--- a/packages/forms/admin_login_test.go
+++ b/packages/forms/admin_login_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminLoginValidateAndSubmit(t *testing.T) {

--- a/packages/forms/admin_password_reset_confirm_test.go
+++ b/packages/forms/admin_password_reset_confirm_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminPasswordResetConfirmValidateAndSubmit(t *testing.T) {

--- a/packages/forms/admin_password_reset_request_test.go
+++ b/packages/forms/admin_password_reset_request_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAdminPasswordResetRequestValidateAndSubmit(t *testing.T) {

--- a/packages/forms/admin_upsert_test.go
+++ b/packages/forms/admin_upsert_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNewAdminUpsert(t *testing.T) {

--- a/packages/forms/apple_client_secret_create_test.go
+++ b/packages/forms/apple_client_secret_create_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAppleClientSecretCreateValidateAndSubmit(t *testing.T) {

--- a/packages/forms/backup_create_test.go
+++ b/packages/forms/backup_create_test.go
@@ -6,7 +6,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestBackupCreateValidateAndSubmit(t *testing.T) {

--- a/packages/forms/backup_upload_test.go
+++ b/packages/forms/backup_upload_test.go
@@ -7,8 +7,8 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestBackupUploadValidateAndSubmit(t *testing.T) {

--- a/packages/forms/collection_upsert_test.go
+++ b/packages/forms/collection_upsert_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/dbutils"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 	"github.com/spf13/cast"
 )
 

--- a/packages/forms/collections_import_test.go
+++ b/packages/forms/collections_import_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestCollectionsImportValidate(t *testing.T) {

--- a/packages/forms/record_email_change_confirm_test.go
+++ b/packages/forms/record_email_change_confirm_test.go
@@ -8,8 +8,8 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordEmailChangeConfirmValidateAndSubmit(t *testing.T) {

--- a/packages/forms/record_email_change_request_test.go
+++ b/packages/forms/record_email_change_request_test.go
@@ -8,7 +8,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordEmailChangeRequestValidateAndSubmit(t *testing.T) {

--- a/packages/forms/record_oauth2_login_test.go
+++ b/packages/forms/record_oauth2_login_test.go
@@ -6,7 +6,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestUserOauth2LoginValidate(t *testing.T) {

--- a/packages/forms/record_password_login_test.go
+++ b/packages/forms/record_password_login_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordPasswordLoginValidateAndSubmit(t *testing.T) {

--- a/packages/forms/record_password_reset_confirm_test.go
+++ b/packages/forms/record_password_reset_confirm_test.go
@@ -8,8 +8,8 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordPasswordResetConfirmValidateAndSubmit(t *testing.T) {

--- a/packages/forms/record_password_reset_request_test.go
+++ b/packages/forms/record_password_reset_request_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordPasswordResetRequestSubmit(t *testing.T) {

--- a/packages/forms/record_upsert_test.go
+++ b/packages/forms/record_upsert_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func hasRecordFile(app core.App, record *models.Record, filename string) bool {

--- a/packages/forms/record_verification_confirm_test.go
+++ b/packages/forms/record_verification_confirm_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordVerificationConfirmValidateAndSubmit(t *testing.T) {

--- a/packages/forms/record_verification_request_test.go
+++ b/packages/forms/record_verification_request_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordVerificationRequestSubmit(t *testing.T) {

--- a/packages/forms/settings_upsert_test.go
+++ b/packages/forms/settings_upsert_test.go
@@ -9,8 +9,8 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
 	"github.com/pocketbase/pocketbase/packages/models/settings"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNewSettingsUpsert(t *testing.T) {

--- a/packages/forms/test_email_send_test.go
+++ b/packages/forms/test_email_send_test.go
@@ -6,7 +6,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestEmailSendValidateAndSubmit(t *testing.T) {

--- a/packages/forms/test_s3_filesystem_test.go
+++ b/packages/forms/test_s3_filesystem_test.go
@@ -5,7 +5,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/packages/forms"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestS3FilesystemValidate(t *testing.T) {

--- a/packages/forms/validators/file_test.go
+++ b/packages/forms/validators/file_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/forms/validators"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
 	"github.com/pocketbase/pocketbase/packages/tools/rest"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestUploadedFileSize(t *testing.T) {

--- a/packages/forms/validators/model_test.go
+++ b/packages/forms/validators/model_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/forms/validators"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestUniqueId(t *testing.T) {

--- a/packages/forms/validators/record_data_test.go
+++ b/packages/forms/validators/record_data_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pocketbase/pocketbase/packages/forms/validators"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
 	"github.com/pocketbase/pocketbase/packages/tools/rest"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 type testDataFieldScenario struct {

--- a/packages/mails/admin_test.go
+++ b/packages/mails/admin_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/mails"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestSendAdminPasswordReset(t *testing.T) {

--- a/packages/mails/record_test.go
+++ b/packages/mails/record_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/pocketbase/pocketbase/packages/mails"
-	"github.com/pocketbase/pocketbase/packages/tests"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestSendRecordPasswordReset(t *testing.T) {

--- a/packages/plugins/jsvm/binds_test.go
+++ b/packages/plugins/jsvm/binds_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/pocketbase/pocketbase/packages/daos"
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
 	"github.com/pocketbase/pocketbase/packages/tools/mailer"
 	"github.com/pocketbase/pocketbase/packages/tools/security"
+	"github.com/pocketbase/pocketbase/tests"
 	"github.com/spf13/cast"
 )
 

--- a/packages/plugins/migratecmd/migratecmd_test.go
+++ b/packages/plugins/migratecmd/migratecmd_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/models/schema"
 	"github.com/pocketbase/pocketbase/packages/plugins/migratecmd"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/types"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestAutomigrateCollectionCreate(t *testing.T) {

--- a/packages/resolvers/record_field_resolver_test.go
+++ b/packages/resolvers/record_field_resolver_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pocketbase/pocketbase/packages/models"
 	"github.com/pocketbase/pocketbase/packages/resolvers"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/list"
 	"github.com/pocketbase/pocketbase/packages/tools/search"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestRecordFieldResolverUpdateQuery(t *testing.T) {

--- a/packages/tokens/admin_test.go
+++ b/packages/tokens/admin_test.go
@@ -3,8 +3,8 @@ package tokens_test
 import (
 	"testing"
 
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tokens"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNewAdminAuthToken(t *testing.T) {

--- a/packages/tokens/record_test.go
+++ b/packages/tokens/record_test.go
@@ -3,8 +3,8 @@ package tokens_test
 import (
 	"testing"
 
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tokens"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNewRecordAuthToken(t *testing.T) {

--- a/packages/tools/filesystem/file_test.go
+++ b/packages/tools/filesystem/file_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v5"
-	"github.com/pocketbase/pocketbase/packages/tests"
 	"github.com/pocketbase/pocketbase/packages/tools/filesystem"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
 func TestNewFileFromPath(t *testing.T) {


### PR DESCRIPTION
# Overview

Un-rename the package references from `pocketbase/packages/tests` to `pocketbase/packages`.